### PR TITLE
#92 - change thumbnail size

### DIFF
--- a/app/services/spotlight/resources/oaipmh_builder.rb
+++ b/app/services/spotlight/resources/oaipmh_builder.rb
@@ -162,7 +162,7 @@ private
         #Change /view/ to /iiif/
         uri = uri.sub(%r|/view/|, "/iiif/")
         #Append /info.json to end
-        uri = uri + "/full/180,/0/native.jpg"
+        uri = uri + "/full/300,/0/native.jpg"
       end
 
     end


### PR DESCRIPTION
# Summary
This commit changes the requested size for thumbnails being rendered in the widgets and throughout the site from 180px to 300px wide

## Related ticket
https://github.com/harvard-lts/CURIOSity/issues/92

## Video
This video show how I can update the url in the browser from 180 to 300px width, and the images will no longer be blurry within the widgets

https://share.getcloudapp.com/YEukDLd5

## Testing
Testing this locally is blocked by [getting harvesting working](https://github.com/harvard-lts/CURIOSity/issues/13), since the urls are created with a 180px width during the harvesting process. 