### PR TITLE
Rename OaipmhModsItem and OaiUpload

### DIFF
--- a/app/jobs/spotlight/resources/perform_harvests_job.rb
+++ b/app/jobs/spotlight/resources/perform_harvests_job.rb
@@ -74,7 +74,7 @@ module Spotlight::Resources
       item.uniquify_repos(repository_field_name)
 
       # Add clean resource for editing
-      new_resource = OaiUpload.find_or_create_by(exhibit: exhibit, external_id: item.id) do |new_r|
+      new_resource = OaipmhUpload.find_or_create_by(exhibit: exhibit, external_id: item.id) do |new_r|
         new_r.data = item_sidecar
       end
       new_resource.attach_image if Spotlight::Oaipmh::Resources.download_full_image

--- a/app/jobs/spotlight/resources/perform_harvests_job.rb
+++ b/app/jobs/spotlight/resources/perform_harvests_job.rb
@@ -60,7 +60,7 @@ module Spotlight::Resources
     end
 
     def harvest_item(record)
-      item = OaipmhModsItem.new(exhibit, oai_mods_converter)
+      item = OaipmhModsParser.new(exhibit, oai_mods_converter)
 
       item.metadata = record.metadata
       item.parse_mods_record

--- a/app/models/spotlight/resources/oaipmh_mods_parser.rb
+++ b/app/models/spotlight/resources/oaipmh_mods_parser.rb
@@ -5,8 +5,7 @@ require 'mods'
 include OAI::XPath
 include Spotlight::Resources::Exceptions
 module Spotlight::Resources
-  # TODO: rename to OaipmhModsParser?
-  class OaipmhModsItem
+  class OaipmhModsParser
     extend CarrierWave::Mount
     attr_reader :titles, :id, :solr_hash, :exhibit
     attr_accessor :metadata, :sidecar_data

--- a/app/models/spotlight/resources/oaipmh_upload.rb
+++ b/app/models/spotlight/resources/oaipmh_upload.rb
@@ -4,7 +4,7 @@ module Spotlight
   module Resources
     ##
     # Exhibit-specific resources, created using uploaded and custom fields
-    class OaiUpload < Spotlight::Resources::Upload
+    class OaipmhUpload < Spotlight::Resources::Upload
       def attach_image
         return if self.data['full_image_url_ssm'].blank?
         image = self.upload || self.create_upload

--- a/spec/models/spotlight/resources/oaipmh_mods_parser_spec.rb
+++ b/spec/models/spotlight/resources/oaipmh_mods_parser_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 
-  RSpec.describe Spotlight::Resources::OaipmhModsItem, type: :model do
+  RSpec.describe Spotlight::Resources::OaipmhModsParser, type: :model do
     let(:exhibit) { FactoryGirl.create(:exhibit) }
     let(:converter) { Spotlight::Resources::OaipmhModsConverter.new('CNA', 'test-exhibit-name')}
     subject { described_class.new(exhibit, converter) }


### PR DESCRIPTION
- Rename OaiUpload to OaipmhUpload to follow naming convention
- Rename OaipmhModsItem to OaipmhModsParser to better reflect its purpose and avoid confusion with OaipmhUpload