### PR TITLE
Log harvest updates less frequently

### DIFF
--- a/app/models/spotlight/oaipmh_harvester.rb
+++ b/app/models/spotlight/oaipmh_harvester.rb
@@ -40,9 +40,11 @@ module Spotlight
           harvests = resumption_oaipmh_harvests(resumption_token)
           resumption_token = harvests.resumption_token
           update_progress_total(job_progress) # set size can change mid-harvest
-          if job_tracker.present?
-            job_tracker.append_log_entry(type: :info, exhibit: exhibit, message: "#{job_progress.progress} of #{job_progress.total} (#{self.total_errors} errors)")
-          end
+        end
+
+        # Log an update every 100 records
+        if (job_progress.progress % 100).zero?
+          job_tracker.append_log_entry(type: :info, exhibit: exhibit, message: "#{job_progress.progress} of #{job_progress.total} (#{self.total_errors} errors)")
         end
       end
     end


### PR DESCRIPTION
Ref https://github.com/harvard-lts/CURIOSity/issues/113

## Summary

Log an update every 100 records (instead of every 10)

![Curation - Dashboard dev - Harvard Curiosity 2022-07-28 at 4 51 47 PM](https://user-images.githubusercontent.com/32469930/181655788-9794b609-89f1-4403-b050-1fd6bb673bee.jpg)

Interested parties: @dl-maura @phil-plencner-hl 