### PR TITLE
DRAFT: Add new key for searching

### DIFF
--- a/app/models/spotlight/oaipmh_harvester.rb
+++ b/app/models/spotlight/oaipmh_harvester.rb
@@ -53,6 +53,7 @@ module Spotlight
       parsed_oai_item.metadata = record.metadata
       parsed_oai_item.parse_mods_record
       parsed_oai_item.uppercase_unique_id
+      parsed_oai_item.search_id
       parsed_oai_item.to_solr
       parsed_oai_item_sidecar = parsed_oai_item.sidecar_data
 

--- a/app/models/spotlight/resources/oaipmh_mods_parser.rb
+++ b/app/models/spotlight/resources/oaipmh_mods_parser.rb
@@ -60,6 +60,12 @@ module Spotlight::Resources
         solr_hash["unique-id_tesim"] = solr_hash["unique-id_tesim"].upcase!
       end
     end
+
+    def search_id
+      # strip out decimal and store in hashes
+      solr_hash['search-id_tesim'] = sidecar_data['search-id_tesim'] = solr_hash['unique-id_tesim'].gsub('.', '')
+    end
+
     def add_document_id
       solr_hash[:id] = @id.to_s
     end


### PR DESCRIPTION
ref https://github.com/harvard-lts/CURIOSity/issues/111

# Summary

- added new searchable field
- users can use the ladder half of the `external_id` to search

![harvard-111](https://user-images.githubusercontent.com/19597776/182206970-f803f68d-971e-43af-9889-7d3167f329d9.gif)
