### PR TITLE
add user and metadata_type to schema

### DIFF
--- a/db/migrate/20220802224427_add_metadata_type_and_user_to_oaipmh_harvester.rb
+++ b/db/migrate/20220802224427_add_metadata_type_and_user_to_oaipmh_harvester.rb
@@ -1,0 +1,8 @@
+class AddMetadataTypeAndUserToOaipmhHarvester < ActiveRecord::Migration[6.1]
+  def change
+    change_table :spotlight_oaipmh_harvesters do |t|
+      t.references :user
+      t.string :metadata_type
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/harvard-lts/CURIOSity/issues/116

## Summary

- add two new fields for `OaipmhHarvester`
  - `user` and `metadata_type`

NOTE: originally it was asked to call the field `type`, but `metadata_type` was more appropriate

## Screenshot

![image](https://user-images.githubusercontent.com/19597776/182960139-3d9053ae-26c8-49e1-acd2-bdf578956f6a.png)
