### PR TITLE
i133 Ensure all data updates if an item has already been harvested

### DIFF
--- a/app/models/spotlight/oaipmh_harvester.rb
+++ b/app/models/spotlight/oaipmh_harvester.rb
@@ -57,7 +57,6 @@ module Spotlight
       parsed_oai_item.uppercase_unique_id
       parsed_oai_item.search_id
       parsed_oai_item.to_solr
-      parsed_oai_item_sidecar = parsed_oai_item.sidecar_data
 
       parsed_oai_item.parse_subjects
       parsed_oai_item.parse_types
@@ -65,11 +64,19 @@ module Spotlight
       parsed_oai_item.process_images
       parsed_oai_item.uniquify_repos(repository_field_name)
       # Add clean resource for editing
-      new_resource = Spotlight::Resources::OaipmhUpload.find_or_create_by(exhibit: exhibit, external_id: parsed_oai_item.id.upcase) do |new_r|
-        new_r.data = parsed_oai_item_sidecar
+      resource = Spotlight::Resources::OaipmhUpload.find_or_create_by(exhibit: exhibit, external_id: parsed_oai_item.id.upcase)
+      resource.data = parsed_oai_item.sidecar_data
+      # If the sidecar for a resource already exists, and new fields have been added between harvests, they
+      # the new key(s) will not persist on the Solr document. To ensure all keys always update, merge in
+      # the whole data hash if the sidecar already exists before indexing.
+      if resource.solr_document_sidecars.present?
+        sidecar = resource.solr_document_sidecars.first
+        sidecar.data['configured_fields'].merge!(resource.data)
+        sidecar.save
+        resource.reload
       end
-      new_resource.attach_image if Spotlight::Oaipmh::Resources.download_full_image
-      new_resource.save_and_index
+      resource.attach_image if Spotlight::Oaipmh::Resources.download_full_image
+      resource.save_and_index
 
       job_progress&.increment
     rescue Exception => e

--- a/app/models/spotlight/oaipmh_harvester.rb
+++ b/app/models/spotlight/oaipmh_harvester.rb
@@ -65,7 +65,7 @@ module Spotlight
       parsed_oai_item.process_images
 
       # Create clean resource for editing
-      resource = Spotlight::Resources::OaipmhUpload.find_or_create_by(exhibit: exhibit, external_id: parsed_oai_item.id.upcase)
+      resource = Spotlight::Resources::OaipmhUpload.find_or_initialize_by(exhibit: exhibit, external_id: parsed_oai_item.id.upcase)
       resource.data = parsed_oai_item.sidecar_data
       # If the sidecar for a resource already exists, and new fields have been added between harvests, then
       # the new key(s) will not persist on the Solr document. To ensure all keys always update, merge in

--- a/app/models/spotlight/oaipmh_harvester.rb
+++ b/app/models/spotlight/oaipmh_harvester.rb
@@ -73,7 +73,8 @@ module Spotlight
         sidecar = resource.solr_document_sidecars.first
         sidecar.data['configured_fields'].merge!(resource.data)
         sidecar.save
-        resource.reload
+        # we edited this to reload the sidecar data, because resource.reload was overwriting the data we were trying to change
+        resource.solr_document_sidecars.map(&:reload)
       end
       resource.attach_image if Spotlight::Oaipmh::Resources.download_full_image
       resource.save_and_index

--- a/app/models/spotlight/oaipmh_harvester.rb
+++ b/app/models/spotlight/oaipmh_harvester.rb
@@ -61,9 +61,10 @@ module Spotlight
       parsed_oai_item.parse_subjects
       parsed_oai_item.parse_types
       repository_field_name = oai_mods_converter.get_spotlight_field_name('repository_ssim')
-      parsed_oai_item.process_images
       parsed_oai_item.uniquify_repos(repository_field_name)
-      # Add clean resource for editing
+      parsed_oai_item.process_images
+
+      # Create clean resource for editing
       resource = Spotlight::Resources::OaipmhUpload.find_or_create_by(exhibit: exhibit, external_id: parsed_oai_item.id.upcase)
       resource.data = parsed_oai_item.sidecar_data
       # If the sidecar for a resource already exists, and new fields have been added between harvests, then

--- a/app/models/spotlight/oaipmh_harvester.rb
+++ b/app/models/spotlight/oaipmh_harvester.rb
@@ -66,14 +66,14 @@ module Spotlight
       # Add clean resource for editing
       resource = Spotlight::Resources::OaipmhUpload.find_or_create_by(exhibit: exhibit, external_id: parsed_oai_item.id.upcase)
       resource.data = parsed_oai_item.sidecar_data
-      # If the sidecar for a resource already exists, and new fields have been added between harvests, they
+      # If the sidecar for a resource already exists, and new fields have been added between harvests, then
       # the new key(s) will not persist on the Solr document. To ensure all keys always update, merge in
       # the whole data hash if the sidecar already exists before indexing.
       if resource.solr_document_sidecars.present?
         sidecar = resource.solr_document_sidecars.first
         sidecar.data['configured_fields'].merge!(resource.data)
-        sidecar.save
-        # we edited this to reload the sidecar data, because resource.reload was overwriting the data we were trying to change
+        sidecar.save!
+        # Get the updated sidecar data into our local variable
         resource.solr_document_sidecars.map(&:reload)
       end
       resource.attach_image if Spotlight::Oaipmh::Resources.download_full_image


### PR DESCRIPTION
Ref https://github.com/harvard-lts/CURIOSity/issues/133

`find_or_create_by` won't execute its `do` block if a record is found. This was skipping the update of data for existing records. Additionally, newly added fields were not persisting on records that already existed. This PR fixes both issues 