### PR TITLE
Hotfix: #search_id 500 errors

### DIFF
--- a/app/models/spotlight/oaipmh_harvester.rb
+++ b/app/models/spotlight/oaipmh_harvester.rb
@@ -55,10 +55,10 @@ module Spotlight
       parsed_oai_item.metadata = record.metadata
       parsed_oai_item.parse_mods_record
       parsed_oai_item.uppercase_unique_id
-      parsed_oai_item.search_id(exhibit.id)
       parsed_oai_item.to_solr
       parsed_oai_item_sidecar = parsed_oai_item.sidecar_data
 
+      parsed_oai_item.search_id(exhibit.id)
       parsed_oai_item.parse_subjects
       parsed_oai_item.parse_types
       repository_field_name = oai_mods_converter.get_spotlight_field_name('repository_ssim')

--- a/app/models/spotlight/resources/oaipmh_mods_parser.rb
+++ b/app/models/spotlight/resources/oaipmh_mods_parser.rb
@@ -62,19 +62,19 @@ module Spotlight::Resources
     end
 
     def search_id(exhibit_id)
-      return if @item_solr['thumbnail_url_ssm'].blank?
-
       # strip out decimal and store in hashes
       id_arr = []
       id_arr << solr_hash['unique-id_tesim'].gsub('.', '') # stripped_decimals
       id_arr << "#{exhibit_id}-#{solr_hash['unique-id_tesim'].gsub('.', '')}" # stripped_decimals w/ exhibit id
       id_arr << solr_hash['unique-id_tesim'].gsub('.', '').gsub(':', '') # all_punc_stripped
       id_arr << "#{exhibit_id}-#{solr_hash['unique-id_tesim'].gsub('.', '').gsub(':', '')}" # all_punc_stripped w/ exhibit id
-      id_arr << urn = fetch_ids_uri(@item_solr['thumbnail_url_ssm']).split('/').last.split('?').first # urn
-      id_arr << urn.gsub('.', '').gsub(':', '') # urn with punc stripped
+      if @item_solr['thumbnail_url_ssm'].present?
+        id_arr << urn = fetch_ids_uri(@item_solr['thumbnail_url_ssm']).split('/').last.split('?').first # urn
+        id_arr << urn.gsub('.', '').gsub(':', '') # urn with punc stripped
+        parsed_urn_id(urn)
+      end
 
       solr_hash['search-id_tesim'] = sidecar_data['search-id_tesim'] = id_arr.compact_blank
-      parsed_urn_id(urn)
     end
 
     def add_document_id

--- a/app/models/spotlight/resources/oaipmh_mods_parser.rb
+++ b/app/models/spotlight/resources/oaipmh_mods_parser.rb
@@ -68,11 +68,13 @@ module Spotlight::Resources
       id_arr << "#{exhibit_id}-#{solr_hash['unique-id_tesim'].gsub('.', '')}" # stripped_decimals w/ exhibit id
       id_arr << solr_hash['unique-id_tesim'].gsub('.', '').gsub(':', '') # all_punc_stripped
       id_arr << "#{exhibit_id}-#{solr_hash['unique-id_tesim'].gsub('.', '').gsub(':', '')}" # all_punc_stripped w/ exhibit id
-      id_arr << urn = fetch_ids_uri(@item_solr['thumbnail_url_ssm']).split('/').last.split('?').first # urn
-      id_arr << urn.gsub('.', '').gsub(':', '') # urn with punc stripped
+      if @item_solr['thumbnail_url_ssm'].present?
+        id_arr << urn = fetch_ids_uri(@item_solr['thumbnail_url_ssm']).split('/').last.split('?').first # urn
+        id_arr << urn.gsub('.', '').gsub(':', '') # urn with punc stripped
+        parsed_urn_id(urn)
+      end
 
       solr_hash['search-id_tesim'] = sidecar_data['search-id_tesim'] = id_arr.compact_blank
-      parsed_urn_id(urn)
     end
 
     def add_document_id

--- a/app/models/spotlight/resources/oaipmh_mods_parser.rb
+++ b/app/models/spotlight/resources/oaipmh_mods_parser.rb
@@ -62,19 +62,19 @@ module Spotlight::Resources
     end
 
     def search_id(exhibit_id)
+      return if @item_solr['thumbnail_url_ssm'].blank?
+
       # strip out decimal and store in hashes
       id_arr = []
       id_arr << solr_hash['unique-id_tesim'].gsub('.', '') # stripped_decimals
       id_arr << "#{exhibit_id}-#{solr_hash['unique-id_tesim'].gsub('.', '')}" # stripped_decimals w/ exhibit id
       id_arr << solr_hash['unique-id_tesim'].gsub('.', '').gsub(':', '') # all_punc_stripped
       id_arr << "#{exhibit_id}-#{solr_hash['unique-id_tesim'].gsub('.', '').gsub(':', '')}" # all_punc_stripped w/ exhibit id
-      if @item_solr['thumbnail_url_ssm'].present?
-        id_arr << urn = fetch_ids_uri(@item_solr['thumbnail_url_ssm']).split('/').last.split('?').first # urn
-        id_arr << urn.gsub('.', '').gsub(':', '') # urn with punc stripped
-        parsed_urn_id(urn)
-      end
+      id_arr << urn = fetch_ids_uri(@item_solr['thumbnail_url_ssm']).split('/').last.split('?').first # urn
+      id_arr << urn.gsub('.', '').gsub(':', '') # urn with punc stripped
 
       solr_hash['search-id_tesim'] = sidecar_data['search-id_tesim'] = id_arr.compact_blank
+      parsed_urn_id(urn)
     end
 
     def add_document_id


### PR DESCRIPTION
## Summary

Two things were happening:
1. `#search_id` needed `@item_solr`, which is not set until `parsed_oai_item.to_solr` is called
2. if `thumbnail_url_ssm` was blank, an error would be thrown