### PR TITLE
i125 Add Manifest URL field

### DIFF
--- a/app/models/spotlight/resources/oaipmh_mods_parser.rb
+++ b/app/models/spotlight/resources/oaipmh_mods_parser.rb
@@ -110,19 +110,23 @@ module Spotlight::Resources
       end
 
       if(@item_solr['full_image_url_ssm'].present? && !@item_solr['full_image_url_ssm'].eql?('null') && !Spotlight::Oaipmh::Resources.download_full_image)
-        full_url = transform_to_view_urls(@item_solr['full_image_url_ssm'])
+        full_url = transform_urls(@item_solr['full_image_url_ssm'], 'VIEW')
         @item_solr['full_image_url_ssm'] = full_url
         @item_sidecar['full_image_url_ssm'] = full_url
+
+        manifest_url = transform_urls(@item_solr['full_image_url_ssm'], 'MANIFEST')
+        @item_solr['manifest_url_ssm'] = manifest_url
+        @item_sidecar['manifest_url_ssm'] = manifest_url
       end
     end
 
-    def transform_to_view_urls(url_string)
+    def transform_urls(url_string, suffix)
       url_string.gsub!(/\?.*$/, '')
       parts = url_string.split('/')
       tail = parts.last
       tail_parts = tail.split(':')
       if tail != tail_parts.join('')
-        tail_parts[3] = 'VIEW'
+        tail_parts[3] = suffix
         tail = tail_parts.join(':')
         parts[-1] = tail
         url_string = parts.join('/')

--- a/spec/models/spotlight/resources/oaipmh_mods_parser_spec.rb
+++ b/spec/models/spotlight/resources/oaipmh_mods_parser_spec.rb
@@ -91,26 +91,51 @@ require 'spec_helper'
     end
   end
 
-  describe 'transform_to_view_urls' do
-    let(:result) {"https://nrs.harvard.edu/urn-3:FHCL:562283:VIEW"}
-    it 'strips params off and adds view' do
-      url_string = "https://nrs.harvard.edu/urn-3:FHCL:562283?buttons=y"
-      expect(subject.transform_to_view_urls(url_string)).to eq(result)
+  describe 'transform_urls' do
+    context 'when adding the :VIEW suffix'
+      let(:result) {"https://nrs.harvard.edu/urn-3:FHCL:562283:VIEW"}
+      it 'strips params off and adds view' do
+        url_string = "https://nrs.harvard.edu/urn-3:FHCL:562283?buttons=y"
+        expect(subject.transform_urls(url_string, 'VIEW')).to eq(result)
+      end
+
+      it 'strips params off and does not add view if view is present' do
+        url_string = "https://nrs.harvard.edu/urn-3:FHCL:562283:VIEW?buttons=y"
+        expect(subject.transform_urls(url_string, 'VIEW')).to eq(result)
+      end
+
+      it 'strips params off and changes manifest for view' do
+        url_string = "https://nrs.harvard.edu/urn-3:FHCL:562283:MANIFEST?buttons=y"
+        expect(subject.transform_urls(url_string, 'VIEW')).to eq(result)
+      end
+
+      it 'adds view if no params or view type is present' do
+        url_string = "https://nrs.harvard.edu/urn-3:FHCL:562283"
+        expect(subject.transform_urls(url_string, 'VIEW')).to eq(result)
+      end
     end
 
-    it 'strips params off and does not add view if view is present' do
-      url_string = "https://nrs.harvard.edu/urn-3:FHCL:562283:VIEW?buttons=y"
-      expect(subject.transform_to_view_urls(url_string)).to eq(result)
-    end
+    context 'when adding the :MANIFEST suffix'
+      let(:result) {"https://nrs.harvard.edu/urn-3:FHCL:562283:MANIFEST"}
+      it 'strips params off and adds MANIFEST' do
+        url_string = "https://nrs.harvard.edu/urn-3:FHCL:562283?buttons=y"
+        expect(subject.transform_urls(url_string, 'MANIFEST')).to eq(result)
+      end
 
-    it 'strips params off and changes manifest for view' do
-      url_string = "https://nrs.harvard.edu/urn-3:FHCL:562283:MANIFEST?buttons=y"
-      expect(subject.transform_to_view_urls(url_string)).to eq(result)
-    end
+      it 'strips params off and does not add MANIFEST if MANIFEST is present' do
+        url_string = "https://nrs.harvard.edu/urn-3:FHCL:562283:MANIFEST?buttons=y"
+        expect(subject.transform_urls(url_string, 'MANIFEST')).to eq(result)
+      end
 
-    it 'adds view if no params or view type is present' do
-      url_string = "https://nrs.harvard.edu/urn-3:FHCL:562283"
-      expect(subject.transform_to_view_urls(url_string)).to eq(result)
+      it 'strips params off and changes manifest for MANIFEST' do
+        url_string = "https://nrs.harvard.edu/urn-3:FHCL:562283:MANIFEST?buttons=y"
+        expect(subject.transform_urls(url_string, 'MANIFEST')).to eq(result)
+      end
+
+      it 'adds MANIFEST if no params or MANIFEST type is present' do
+        url_string = "https://nrs.harvard.edu/urn-3:FHCL:562283"
+        expect(subject.transform_urls(url_string, 'MANIFEST')).to eq(result)
+      end
     end
   end
 end


### PR DESCRIPTION
Ref https://github.com/harvard-lts/CURIOSity/issues/125 

Relies on https://gitlab.com/notch8/harvard-curiosity/-/merge_requests/120 

## Summary

Add manifest version of the image url to the solr document