### PR TITLE
i160 Add validations to Harvester

### DIFF
--- a/app/models/spotlight/oaipmh_harvester.rb
+++ b/app/models/spotlight/oaipmh_harvester.rb
@@ -6,6 +6,9 @@ module Spotlight
   class OaipmhHarvester < ActiveRecord::Base
     belongs_to :exhibit
 
+    validates :base_url, presence: true
+    validates :set, presence: true
+
     attr_accessor :total_errors
 
     def self.mapping_files

--- a/app/views/spotlight/resources/oaipmh_harvester/_form.html.erb
+++ b/app/views/spotlight/resources/oaipmh_harvester/_form.html.erb
@@ -1,6 +1,6 @@
 <%= bootstrap_form_for([current_exhibit, @resource.becomes(Spotlight::OaipmhHarvester)], url: spotlight_oaipmh_resources_engine.exhibit_oaipmh_harvester_path(exhibit_id: current_exhibit), layout: :horizontal, label_col: 'col-md-2', control_col: 'col-sm-6 col-md-6' ) do |f| %>
-  <%= f.text_field :url, help: t('.url-field.help'), label: t('.url') %>
-  <%= f.text_field :set, help: t('.set-field.help'), label: t('.set') %>
+  <%= f.text_field :url, help: t('.url-field.help'), label: t('.url'), required: true %>
+  <%= f.text_field :set, help: t('.set-field.help'), label: t('.set'), required: true %>
   <%= f.select :mapping_file, 
     Spotlight::OaipmhHarvester.mapping_files, 
     { help: t('.mapping-file-field.help'), label: t('.mapping-file') }, 


### PR DESCRIPTION
Ref https://github.com/harvard-lts/CURIOSity/issues/160

Add validations to harvester to disallow empty harvests from "succeeding". Attempting to submit any empty fields on the harvest form will be stopped with a pop up saying the fields are required: 

![Curation - Add items CURIOSity Demo Site - Harvard Curiosity 2022-08-24 at 10 17 38 AM](https://user-images.githubusercontent.com/32469930/186482272-854d8b04-2c83-4777-b96e-aa2097dfce35.jpg)
