### PR TITLE
i148 Harvested thumbnails respect dimension config

### DIFF
--- a/app/models/spotlight/oaipmh_harvester.rb
+++ b/app/models/spotlight/oaipmh_harvester.rb
@@ -91,12 +91,13 @@ module Spotlight
 
       job_progress&.increment
     rescue Exception => e
-      error_msg = parsed_oai_item.id + ' did not index successfully'
+      error_msg = parsed_oai_item.id + ' did not index successfully:'
       Delayed::Worker.logger.add(Logger::ERROR, error_msg)
       Delayed::Worker.logger.add(Logger::ERROR, e.message)
       Delayed::Worker.logger.add(Logger::ERROR, e.backtrace)
       if job_tracker.present?
         job_tracker.append_log_entry(type: :error, exhibit: exhibit, message: error_msg)
+        job_tracker.append_log_entry(type: :error, exhibit: exhibit, message: e.message)
       end
       self.total_errors += 1
     end

--- a/app/models/spotlight/resources/oaipmh_mods_parser.rb
+++ b/app/models/spotlight/resources/oaipmh_mods_parser.rb
@@ -186,8 +186,9 @@ module Spotlight::Resources
       # Change /view/ to /iiif/
       uri = uri.sub(%r|/view/|, '/iiif/')
       # Append iiif format (thumbnail version)
+      thumbnail_size = Spotlight::Engine.config.featured_image_thumb_size&.[](0) || 300
       uri = uri.gsub(/\/full\/\d*,\d*\/0\/default.jpg/, '')
-      uri += '/full/300,/0/native.jpg'
+      uri += "/full/#{thumbnail_size},/0/native.jpg"
     end
   end
 end


### PR DESCRIPTION
Ref https://github.com/harvard-lts/CURIOSity/issues/148 

- [ ] **This change has been released**

## Summary

Instead of hard-coding the harvested thumbnails dimension, use the configurable setting (`Spotlight::Engine.config.featured_image_thumb_size`). 

![- demo - Harvard Curiosity Search Results 2022-09-02 at 9 51 39 AM](https://user-images.githubusercontent.com/32469930/188201976-ad113d70-1450-4bb3-ad37-c9d3fc5863c0.jpg)

Also, for items that failed to harvest, show the error message. 

![Curation - Dashboard demo - Harvard Curiosity 2022-09-02 at 9 54 49 AM](https://user-images.githubusercontent.com/32469930/188202313-eda067c5-304a-4e4c-9a85-a5cf4d9fa521.jpg)
