### PR TITLE
Exhibit-specific fields work with harvesting

### DIFF
--- a/app/models/spotlight/resources/oaipmh_mods_parser.rb
+++ b/app/models/spotlight/resources/oaipmh_mods_parser.rb
@@ -203,7 +203,7 @@ module Spotlight::Resources
       if configured_field_names.include?(field_name)
         item_sidecar[field_name] = value
       else
-        custom_field_slug = field_name.sub(/_.*$/, '')
+        custom_field_slug = field_name.sub(/_[^_]+$/, '')
         item_sidecar[custom_field_slug] = value
       end
     end

--- a/app/models/spotlight/resources/oaipmh_mods_parser.rb
+++ b/app/models/spotlight/resources/oaipmh_mods_parser.rb
@@ -8,7 +8,7 @@ module Spotlight::Resources
   class OaipmhModsParser
     extend CarrierWave::Mount
     attr_reader :titles, :id, :solr_hash, :exhibit
-    attr_accessor :metadata, :sidecar_data
+    attr_accessor :metadata, :sidecar_data, :item_sidecar
     #attr_accessor :metadata, :itemurl, :sidecar_data
     #mount_uploader :itemurl, Spotlight::ItemUploader
     def initialize(exhibit, converter)
@@ -20,7 +20,9 @@ module Spotlight::Resources
     def to_solr
       add_document_id
       @item_solr = solr_hash
-      @item_sidecar = sidecar_data
+      @item_sidecar = {}
+      # Populate values in @item_sidecar in the correct format
+      sidecar_data.map { |k, v| assign_item_sidecar_data(k, v) }
 
       @item_solr
     end
@@ -74,7 +76,8 @@ module Spotlight::Resources
         parsed_urn_id(urn)
       end
 
-      solr_hash['search-id_tesim'] = sidecar_data['search-id_tesim'] = id_arr.compact_blank
+      solr_hash['search-id_tesim'] = id_arr.compact_blank
+      assign_item_sidecar_data('search-id_tesim', id_arr.compact_blank)
     end
 
     def add_document_id
@@ -87,7 +90,7 @@ module Spotlight::Resources
         # Split on | and ,
         subjects = @item_solr[subject_field_name].split(/[|,]/).flatten
         @item_solr[subject_field_name] = subjects
-        @item_sidecar['subjects_ssim'] = subjects
+        assign_item_sidecar_data('subjects_ssim', subjects)
       end
     end
 
@@ -97,7 +100,7 @@ module Spotlight::Resources
         #Split on |
         types = @item_solr[type_field_name].split('|')
         @item_solr[type_field_name] = types
-        @item_sidecar['type_ssim'] = types
+        assign_item_sidecar_data('type_ssim', types)
       end
     end
 
@@ -106,17 +109,17 @@ module Spotlight::Resources
         thumburl = fetch_ids_uri(@item_solr['thumbnail_url_ssm'])
         thumburl = transform_to_iiif_thumbnail(thumburl) if Spotlight::Oaipmh::Resources.use_iiif_images
         @item_solr['thumbnail_url_ssm'] =  thumburl
-        @item_sidecar['thumbnail_url_ssm'] = thumburl
+        assign_item_sidecar_data('thumbnail_url_ssm', thumburl)
       end
 
       if(@item_solr['full_image_url_ssm'].present? && !@item_solr['full_image_url_ssm'].eql?('null') && !Spotlight::Oaipmh::Resources.download_full_image)
         full_url = transform_urls(@item_solr['full_image_url_ssm'], 'VIEW')
         @item_solr['full_image_url_ssm'] = full_url
-        @item_sidecar['full_image_url_ssm'] = full_url
+        assign_item_sidecar_data('full_image_url_ssm', full_url)
 
         manifest_url = transform_urls(@item_solr['full_image_url_ssm'], 'MANIFEST')
         @item_solr['manifest_url_ssm'] = manifest_url
-        @item_sidecar['manifest_url_ssm'] = manifest_url
+        assign_item_sidecar_data('manifest_url_ssm', manifest_url)
       end
     end
 
@@ -140,7 +143,7 @@ module Spotlight::Resources
         repoarray = @item_solr[repository_field_name].split('|')
         repoarray = repoarray.flatten.uniq
         @item_solr[repository_field_name] = repoarray
-        @item_sidecar['repository_ssim'] = repoarray
+        assign_item_sidecar_data('repository_ssim', repoarray)
       end
     end
 
@@ -153,18 +156,19 @@ module Spotlight::Resources
         datearray = @item_solr[start_date_name].split('|')
         dates = datearray.join('|')
         @item_solr[start_date_name] = dates
-        @item_sidecar['start-date_tesim'] = dates
+        assign_item_sidecar_data('start-date_tesim', dates)
       end
       if end_date.present?
         datearray = @item_solr[end_date_name].split('|')
         dates = datearray.join('|')
         @item_solr[end_date_name] = dates
-        @item_sidecar['end-date_tesim'] = dates
+        assign_item_sidecar_data('end-date_tesim', dates)
       end
     end
 
     def parsed_urn_id(urn)
-      @item_solr['urn_ssi'] = @item_sidecar['urn_ssi'] = urn
+      @item_solr['urn_ssi'] = urn
+      assign_item_sidecar_data('urn_ssi', urn)
     end
 
     # Resolves urn-3 uris
@@ -188,6 +192,36 @@ module Spotlight::Resources
       thumbnail_size = Spotlight::Engine.config.featured_image_thumb_size&.[](0) || 300
       uri = uri.gsub(/\/full\/\d*,\d*\/0\/default.jpg/, '')
       uri += "/full/#{thumbnail_size},/0/native.jpg"
+    end
+
+    # TODO: docs
+    def configured_field_names
+      @configured_field_names ||= ['full_title_tesim'] + exhibit.uploaded_resource_fields.map(&:field_name).map(&:to_s)
+    end
+
+    # TODO: docs
+    def assign_item_sidecar_data(field_name, value)
+      if configured_field_names.include?(field_name)
+        item_sidecar[field_name] = value
+      else
+        custom_field_slug = field_name.sub(/_.*$/, '')
+        item_sidecar[custom_field_slug] = value
+      end
+    end
+
+    # TODO: docs
+    def organize_item_sidecar_data
+      organized_item_sidecar = { 'configured_fields' => {} }
+      custom_field_slugs = exhibit.custom_fields.map(&:slug)
+
+      item_sidecar.map do |field_name, value|
+        organized_item_sidecar['configured_fields'][field_name] = value if configured_field_names.include?(field_name)
+        next unless custom_field_slugs.include?(field_name)
+
+        organized_item_sidecar[field_name] = value
+      end
+
+      organized_item_sidecar
     end
   end
 end


### PR DESCRIPTION
Ref https://github.com/harvard-lts/CURIOSity/issues/170

## Summary

Fixes a bug where exhibit-specific fields were not getting populated with data when harvesting.

## Testing Instructions 

Follow Vanessa's steps [here](https://github.com/harvard-lts/CURIOSity/issues/170#issuecomment-1235589977).

**Expected behavior:** the exhibit-specific fields populate with data when harvesting.

## Explanation 
### Short version

The incoming metadata was not being formatted in the way that Spotlight expects, leading to the bug. Exhibit-specific fields **and** default "configured" fields are now formatted as required.

### Long version

I made several discoveries while troubleshooting this issue:

#### 1. As far as I can tell, the `#data` in a `Spotlight::Resources::OaipmhUpload` has no bearing on the data that gets persisted in Solr

This is partially expected; the resource's associated sidecar's (`Spotlight::SolrDocumentSidecar`) `#data` is what goes to Solr, which is expected. But updating the resource's `#data` (after initial creation) does not automatically update its sidecar; instead, the sidecar's `#data` also has to be updated manually.

<details><summary>Example scenarios</summary>

_Resource creation, works as expected_

```
1. Initialize a resource with data
2. Save the resource
3. The resource's sidecar is created at save time with the resource's data 
4. The sidecar's data gets indexed into Solr
```

_Resource update (attempt to update data in Solr through resource), does not work as expected_ 

```
1. Find existing resource
2. Update resource's #data 
3. Run #save_and_index on resource 
4. Resource updated successfully 
5. Resource's sidecar doesn't change 
6. Unchanged sidecar gets indexed 
7. No data changed in Solr 
```

_Resource update (attempt to update data in Solr through resource's sidecar), succeeds_ 

```
1. Find existing resource 
2. Update resource's #data
3. Update resource's sidecar's #data
4. Run #save_and_index on resource 
5. Updated sidecar gets indexed 
6. Updated data gets persisted in Solr
```

</details>

This is further supported by the fact that if you edit an resource in the UI, it "works" **but** the resource remains unchanged; the resource's sidecar is what changes! 

It feels like the resource only gets used at create time and is vestigial after that. 

#### 2. `OaipmhUpload#data` and `SolrDocumentSidecar#data` expect different formats 

_Example:_

```ruby
# Correct OaipmhUpload#data format
{
  'full_title_tesim' => 'Title',
  'custom-field' => 'Hello world'
}

# Correct SolrDocumentSidecar#data format
{
  'configured_fields' => {
    'full_title_tesim' => 'Title'
  },
  'custom-field' => 'Hello world'
}
```

#### 3. Exhibit-specific fields ("custom fields" in the code) are expected to not have a Solr suffix in the `#data` hashes

```ruby
# Bad
'custom-field_tesim'

# Good
'custom-field'
```