### PR TITLE
Capture more errors in LoadUrnsJob to avoid "false positive" harvest reporting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GIT
 PATH
   remote: .
   specs:
-    spotlight-oaipmh-resources (3.0.0.pre.beta.9)
+    spotlight-oaipmh-resources (3.0.0.pre.beta.10)
       mods
       oai
 

--- a/app/jobs/spotlight/resources/load_urns_job.rb
+++ b/app/jobs/spotlight/resources/load_urns_job.rb
@@ -18,7 +18,7 @@ module Spotlight::Resources
           #
           # https://getbootstrap.com/docs/4.0/content/tables/
           message = "Missing Spotlight::SolrDocumentSidecar for document_id=#{sidecar_id}"
-          job_tracker&.append_log_entry(type: :warning, exhibit: exhibit, message: message)
+          job_tracker.append_log_entry(type: :warning, exhibit: exhibit, message: message)
           total_warnings += 1
           next
         end
@@ -33,10 +33,15 @@ module Spotlight::Resources
           #
           # https://getbootstrap.com/docs/4.0/content/tables/
           message = "Invalid data for Spotlight::SolrDocumentSidecar for document_id=#{sidecar_id}"
-          job_tracker&.append_log_entry(type: :warning, exhibit: exhibit, message: message)
-          job_tracker&.append_log_entry(type: :warning, exhibit: exhibit, message: e.message)
+          job_tracker.append_log_entry(type: :warning, exhibit: exhibit, message: message)
+          job_tracker.append_log_entry(type: :warning, exhibit: exhibit, message: e.message)
           total_warnings += 1
         end
+      rescue StandardError => e
+        message = "An error has occurred when trying to index the URN for document_id=#{sidecar_id}"
+        job_tracker.append_log_entry(type: :warning, exhibit: exhibit, message: message)
+        job_tracker.append_log_entry(type: :warning, exhibit: exhibit, message: %(#{e.class}: #{e.message}))
+        total_warnings += 1
       end
       total_warnings
     end

--- a/lib/spotlight/oaipmh/resources/version.rb
+++ b/lib/spotlight/oaipmh/resources/version.rb
@@ -2,7 +2,7 @@ module Spotlight
   module Oaipmh
     # :nodoc:
     module Resources
-      VERSION = "3.0.0-beta.9"
+      VERSION = "3.0.0-beta.10"
     end
   end
 end


### PR DESCRIPTION
Ref https://github.com/harvard-lts/CURIOSity/issues/215

## Summary

There was a small section in the harvest logic where errors were not being captured and handled. If an error was thrown somewhere in this section, it would cause the initial `PerformHarvestsJob` to fail. This failed job would then retry itself several times, failing silently all the way. And because the errors weren't being captured, no information would be visible to the user looking in modal in the "Recent indexing activity" section of the Exhibit Dashboard.

This PR includes two key changes: 

1. **Capture the error**

Capturing the error prevents the job from retrying itself over and over. This frees up the background working to work on other processes. 

2. **Handle the error**

Handling the error means bubbling it up to the user, specifically in the harvest status modal. This lets the user know 1) something went wrong and 2) possibly what they can do about it.

## Screenshots 

<details><summary>Before</summary>

![Curation - Dashboard demo - Harvard Curiosity 2022-10-10 at 11 41 08 AM](https://user-images.githubusercontent.com/32469930/194932915-846a0663-ea39-4131-8d1a-0f31c052f834.jpg)

</details>

<details><summary>After</summary>

![Curation - Dashboard demo - Harvard Curiosity 2022-10-10 at 11 44 05 AM](https://user-images.githubusercontent.com/32469930/194932945-ec03466f-1fc8-4ac7-aa8e-ba1ab30675e3.jpg)

</details>

## Testing Instructions 

Please refer to [the ticket](https://github.com/harvard-lts/CURIOSity/issues/215). 