### PR TITLE
Allow records with multiple thumbnails to import

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GIT
 PATH
   remote: .
   specs:
-    spotlight-oaipmh-resources (3.0.0.pre.beta.10)
+    spotlight-oaipmh-resources (3.0.0.pre.beta.11)
       mods
       oai
 

--- a/app/models/spotlight/resources/oaipmh_mods_parser.rb
+++ b/app/models/spotlight/resources/oaipmh_mods_parser.rb
@@ -177,7 +177,7 @@ module Spotlight::Resources
 
     # Resolves urn-3 uris
     def fetch_ids_uri(uri_str)
-      if uri_str =~ /urn-3/
+      if uri_str.scan(/urn-3/).size == 1
         response = Net::HTTP.get_response(URI.parse(uri_str))['location']
       elsif uri_str.include?('?')
         uri_str = uri_str.slice(0..(uri_str.index('?')-1))

--- a/lib/spotlight/oaipmh/resources/version.rb
+++ b/lib/spotlight/oaipmh/resources/version.rb
@@ -2,7 +2,7 @@ module Spotlight
   module Oaipmh
     # :nodoc:
     module Resources
-      VERSION = "3.0.0-beta.10"
+      VERSION = "3.0.0-beta.11"
     end
   end
 end


### PR DESCRIPTION
## Summary

Only perform HTTP request if there is only one uri.

Some records currently get parsed with multiple thumbnail/full image urls concatenated together. This was throwing errors and preventing the records from coming in at all. For parity with the old site, we now allow these records to be imported with broken images so that at least the record is in the system.

<details><summary>Screenshots</summary>

![Curation - Dashboard jbsd - Harvard Curiosity 2022-10-11 at 12 41 54 PM](https://user-images.githubusercontent.com/32469930/195184906-2fd3da87-ade3-4b2b-ae8b-024b0ff51f54.jpg)

![Echinoderm (Tortugas, Florida, 1858) - jbsd - Harvard Curiosity 2022-10-11 at 12 42 53 PM](https://user-images.githubusercontent.com/32469930/195184917-82e54e98-fb06-428f-8e41-284186e6971d.jpg)

</details>

## Testing Instructions

1. Login as an admin 
2. Harvest the `jbsd` set using the [jbsd.yml](https://github.com/harvard-lts/spotlight-oaipmh-resources/blob/main/harvard_yaml_mapping_files/mods/jbsd.yml) mapping file 
3. When the harvest completes, search for this URN: `ARC_237-032` 
4. The thumbnail won't show up in the search results. This is expected 
5. Click on the item 
6. The Mirador viewer will display an error. This is expected 
7. The record and its metadata existing at all are proof that this is working 