### PR TITLE
i224 Strip whitespaces from URNs when harvesting

### DIFF
--- a/app/models/spotlight/resources/oaipmh_mods_parser.rb
+++ b/app/models/spotlight/resources/oaipmh_mods_parser.rb
@@ -124,6 +124,7 @@ module Spotlight::Resources
     end
 
     def transform_urls(url_string, suffix)
+      url_string.strip!
       res = Net::HTTP.get_response(URI(url_string))
       pageOrder = res['location']&.[](/\$\d*!/)&.gsub(/\$|!/, '')
       pageOrder ||= res['location']&.[](/n=\d*/)&.gsub(/n=/, '')
@@ -177,6 +178,8 @@ module Spotlight::Resources
 
     # Resolves urn-3 uris
     def fetch_ids_uri(uri_str)
+      uri_str.strip!
+
       if uri_str.scan(/urn-3/).size == 1
         response = Net::HTTP.get_response(URI.parse(uri_str))['location']
       elsif uri_str.include?('?')


### PR DESCRIPTION
Ref https://github.com/harvard-lts/CURIOSity/issues/224

<details><summary>Before</summary>

![Slavery, Abolition, Emancipation and Freedom - Harvard Curiosity 2022-10-24 at 4 58 57 PM](https://user-images.githubusercontent.com/32469930/197652173-ac803764-7edb-4bf1-ae72-c44a401e461a.jpg)

</details>

<details><summary>After</summary>

![Slavery, Abolition, Emancipation and Freedom - Harvard Curiosity 2022-10-24 at 4 59 17 PM](https://user-images.githubusercontent.com/32469930/197652202-26f7c5fd-830c-4371-97ad-e1d12df8dbe9.jpg)

</details>

### Testing Instructions 

1. Login as an admin 
2. Create a new exhibit 
3. Harvest the `saef` OAI set (use curiosity.yml mapping file) 
4. When harvest completes, validate that no `bad URI(is not URI?): "https://nrs.harvard.edu/URN-3:FHCL.HOUGH:101211924 "` errors were thrown 