### PR TITLE
Bump row count + Change Set Spec Name

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GIT
 PATH
   remote: .
   specs:
-    spotlight-oaipmh-resources (3.0.0.pre.beta.13)
+    spotlight-oaipmh-resources (3.0.0.pre.beta.14)
       mods
       oai
 

--- a/app/models/spotlight/solr_harvester.rb
+++ b/app/models/spotlight/solr_harvester.rb
@@ -3,7 +3,7 @@ require 'uri'
 
 module Spotlight
   class SolrHarvester < Harvester
-    ROW_COUNT = 50
+    ROW_COUNT = 1000
     DEFAULT_SORT_FIELD = '_id'
 
     alias_attribute :mapping_file, :solr_mapping_file

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,7 +13,7 @@ en:
                 help: "Add the base URL of the data to be harvested."
               set: "Set Spec"
               set-field:
-                help: "Type in the set name to be harvested."
+                help: "Type in the set spec to be harvested."
               mapping-file: "Select Mapping File"
               mapping-file-field:
                 help: "Select Mapping File to Use (default is mapping.yml)."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,7 +11,7 @@ en:
               add_item: "Harvest items"
               url-field:
                 help: "Add the base URL of the data to be harvested."
-              set: "Set name"
+              set: "Set Spec"
               set-field:
                 help: "Type in the set name to be harvested."
               mapping-file: "Select Mapping File"

--- a/lib/spotlight/oaipmh/resources/version.rb
+++ b/lib/spotlight/oaipmh/resources/version.rb
@@ -2,7 +2,7 @@ module Spotlight
   module Oaipmh
     # :nodoc:
     module Resources
-      VERSION = "3.0.0-beta.13"
+      VERSION = "3.0.0-beta.14"
     end
   end
 end


### PR DESCRIPTION
This PR does 2 things:

- bumps the SOLR_ROW count variable to 1000 to speed up solr harvest per Anthony
- changes the Set name labels to Set Spec (per Vanessa)

To test, you'll need to pull this branch and spin up your local. You should see the label Set Spec on the Item harvest page. Then you can harvest a solr collection (I'd suggest scats-calendars as it is the smallest) to confirm my change didn't break anything.