### PR TITLE
Update unique_keys_by_set.yml

### DIFF
--- a/harvard_yaml_mapping_files/solr/unique_key_mappings/unique_keys_by_set.yml
+++ b/harvard_yaml_mapping_files/solr/unique_key_mappings/unique_keys_by_set.yml
@@ -8,6 +8,8 @@
 
 tedming:
   unique_key: id
+ming:
+  unique_key: id
 acat-calendar:
   unique_key: _id
 acat-courses:


### PR DESCRIPTION
This allows VV to use the Ming Alias since it uses a special id field

To test:

Point your local to this branch of the oai gem and rebuild as necessary. You should then be able to do a harvest using the following fields:

Set Spec: ming
Solr Query Filter: painting.format:"Ink on paper"

Before Set Spec: ming would fail but now it will harvest.