### PR TITLE
Add index for `iiif_manifest_url_ssi`

### DIFF
--- a/app/models/spotlight/resources/oaipmh_mods_parser.rb
+++ b/app/models/spotlight/resources/oaipmh_mods_parser.rb
@@ -118,8 +118,11 @@ module Spotlight::Resources
         assign_item_sidecar_data('full_image_url_ssm', full_url)
 
         manifest_url = transform_urls(@item_solr['full_image_url_ssm'], 'MANIFEST')
+        proxy_url = "/iiif/proxy?url=#{manifest_url}"
         @item_solr['manifest_url_ssm'] = manifest_url
+        @item_solr['iiif_manifest_url_ssi'] = proxy_url
         assign_item_sidecar_data('manifest_url_ssm', manifest_url)
+        assign_item_sidecar_data('iiif_manifest_url_ssi', proxy_url)
       end
     end
 


### PR DESCRIPTION
This commit will add an index field for `iiif_manifest_url_ssi` which
would be consumed by Spotlight's appearances controller to set images
(like thumbnails and mastheads) based on the IIIF Manifest of the
resource.  Because Harvard's URIs redirect, a proxy endpoint from the
server is needed to receive the JSON from the redirect.  This is
assuming the route at `iiif/proxy` with the param url=<url>.  This is
what we will index onto the resource to get the IIIF Manifest picked up
by Spotlight.