### PR TITLE
🐛 Fix email string interpolation

### DIFF
--- a/app/mailer/spotlight/harvesting_complete_mailer.rb
+++ b/app/mailer/spotlight/harvesting_complete_mailer.rb
@@ -4,7 +4,7 @@ module Spotlight
   # batch upload
   class HarvestingCompleteMailer < ActionMailer::Base
     def harvest_set_completed(job)
-      @set = job.set
+      @set = job.harvester_set
       @exhibit = job.exhibit
       @total_errors = job.total_errors
       @total_warnings = job.total_warnings


### PR DESCRIPTION
Previously, we had to change set to harvester_set but missed this one.

```log
From: oaiharvester@noreply.com
To: admin@example.com
Message-ID: <684cd95366fd2_281d3ac8272cb@c2f84c988a7d.mail>
Subject: Harvesting complete for demo
Mime-Version: 1.0
Content-Type: text/html;
 charset=UTF-8
Content-Transfer-Encoding: 7bit

<!-- BEGIN gems/spotlight-oaipmh-resources/app/views/spotlight/harvesting_complete_mailer/harvest_set_completed.html.erb --><p>Harvesting complete for demo</p>

<p>The demo set has just finished harvesting to the demo exhibit.
Items may still be in the process of indexing. See admin/jobs for current status.</p>


<!-- END gems/spotlight-oaipmh-resources/app/views/spotlight/harvesting_complete_mailer/harvest_set_completed.html.erb -->
```

Ref:
- https://github.com/harvard-lts/spotlight5/issues/151